### PR TITLE
Фикс некоректной отрисовки EgoldsGoogleTextBox'ов

### DIFF
--- a/yt_DesignUI/Controls/EgoldsGoogleTextBox.cs
+++ b/yt_DesignUI/Controls/EgoldsGoogleTextBox.cs
@@ -3,7 +3,6 @@ using System.ComponentModel;
 using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Windows.Forms;
-using System.Design;
 using System.Windows.Forms.Design;
 using EgoldsUI;
 
@@ -25,11 +24,11 @@ namespace yt_DesignUI
             {
                 // Ограничение, чтобы размер шрифта заголовка нельзя было установить больше, 
                 // чем размер основного шрифта
-                if(value.Size >= Font.Size )
+                if (value.Size >= Font.Size)
                     return;
                 fontTextPreview = value;
             }
-        } 
+        }
 
         public Color BorderColor { get; set; } = FlatColors.Blue;
         public Color BorderColorNotActive { get; set; } = FlatColors.GrayDark;
@@ -40,7 +39,8 @@ namespace yt_DesignUI
             set
             {
                 tbInput.Text = value;
-                Refresh();
+                if (!tbInput.Focused)
+                    TextPreviewAction(TextInput.Length > 0);
             }
         }
 
@@ -50,17 +50,26 @@ namespace yt_DesignUI
             set => tbInput.UseSystemPasswordChar = value;
         }
 
-        //[Browsable(false)]
-        //public new string Text { get; set; }
-        
         public new string Text
         {
             get => tbInput.Text;
             set
             {
                 tbInput.Text = value;
-                Refresh();
+                if (!tbInput.Focused)
+                    TextPreviewAction(TextInput.Length > 0);
             }
+        }
+
+        public int SelectionStart
+        {
+            get => tbInput.SelectionStart;
+            set => tbInput.SelectionStart = value;
+        }
+
+        public int TextLength
+        {
+            get => tbInput.TextLength;
         }
 
         #endregion
@@ -93,7 +102,7 @@ namespace yt_DesignUI
         {
             SetStyle(ControlStyles.AllPaintingInWmPaint | ControlStyles.OptimizedDoubleBuffer | ControlStyles.ResizeRedraw | ControlStyles.SupportsTransparentBackColor | ControlStyles.UserPaint, true);
             DoubleBuffered = true;
-            
+
             Size = new Size(150, 40);
             Font = new Font("Arial", 11.25F, FontStyle.Regular);
             ForeColor = Color.Black;
@@ -133,8 +142,13 @@ namespace yt_DesignUI
             tbInput.Size = new Size(Width - 10, tbInput.Height);
 
             tbInput.LostFocus += TbInput_LostFocus;
+            tbInput.GotFocus += TbInput_GotFocus;
         }
 
+        private void TbInput_GotFocus(object sender, EventArgs e)
+        {
+            TextPreviewAction(true);
+        }
         private void TbInput_LostFocus(object sender, EventArgs e)
         {
             TextPreviewAction(false);
@@ -180,12 +194,12 @@ namespace yt_DesignUI
 
             Font FontTextPreviewActual = new Font(FontTextPreview.FontFamily, FontSizeTextPreviewAnim.Value, FontTextPreview.Style);
 
-            if(tbInput.Visible == false && FontTextPreviewActual.Size <= FontTextPreview.Size)
+            if (!tbInput.Visible && FontTextPreviewActual.Size <= FontTextPreview.Size)
             {
                 tbInput.Visible = true;
                 tbInput.Focus();
             }
-            else if (tbInput.Visible == true && FontTextPreviewActual.Size > FontTextPreview.Size)
+            else if (tbInput.Visible && FontTextPreviewActual.Size > FontTextPreview.Size)
             {
                 tbInput.Visible = false;
             }
@@ -196,16 +210,19 @@ namespace yt_DesignUI
             Rectangle rectTextPreview = new Rectangle(5, (int)LocationTextPreviewAnim.Value, TextPreviewRectSize.Width + 3, TextPreviewRectSize.Height);
 
             // Обводка
-            graph.DrawRectangle(new Pen(tbInput.Focused == true ? BorderColor : BorderColorNotActive), rectBase);
-            
+            graph.DrawRectangle(new Pen(tbInput.Text.Length > 0 || tbInput.Focused ?
+                BorderColor : BorderColorNotActive), rectBase);
+
             // Заголовок/Описание
             graph.DrawRectangle(new Pen(Parent.BackColor), rectTextPreview);
             graph.FillRectangle(new SolidBrush(Parent.BackColor), rectTextPreview);
 
             // Цвет внутри
             graph.FillRectangle(new SolidBrush(BackColor), rectBase);
-            
-            graph.DrawString(TextPreview, FontTextPreviewActual, new SolidBrush(tbInput.Focused == true ? BorderColor : BorderColorNotActive), rectTextPreview, SF);
+
+            graph.DrawString(TextPreview, FontTextPreviewActual,
+                new SolidBrush(tbInput.Text.Length > 0 || tbInput.Focused ?
+                BorderColor : BorderColorNotActive), rectTextPreview, SF);
         }
 
         private void TextPreviewAction(bool OnTop)
@@ -243,19 +260,12 @@ namespace yt_DesignUI
             Animator.Request(FontSizeTextPreviewAnim, true);
         }
 
-        protected override void OnGotFocus(EventArgs e)
-        {
-            base.OnGotFocus(e);
-            TextPreviewAction(true);
-        }
-
         protected override void OnMouseClick(MouseEventArgs e)
         {
             base.OnMouseClick(e);
 
             TextPreviewAction(true);
         }
-
 
 
         /// <summary>


### PR DESCRIPTION
Фикс некоректной отрисовки EgoldsGoogleTextBox'ов (не обновляется Text, не изменяется цвет обводки и TextPreview, либо изменяется некорректно).
Список исправленных багов:
-При изменении свойства Text программно (tbInput.Text = ...), текст обновляется только после клика по EgoldsGoogleTextBox'у.
-При повторном изменении свойства Text (строка не пустая) программно, обводка и TextPreview отрисовываются как неактивные (по умолчанию - серым цветом).

Добавлены свойства SelectionStart и TextLength